### PR TITLE
Fix off-by-one in reported test number

### DIFF
--- a/duckdb_sqllogictest/python_runner.py
+++ b/duckdb_sqllogictest/python_runner.py
@@ -201,7 +201,7 @@ class SQLLogicPythonRunner:
                 executor.skip_log.append(str(e.message))
                 continue
 
-            print(f'[{i}/{total_tests}] {file_path}')
+            print(f'[{i+1}/{total_tests}] {file_path}')
             # This is necessary to clean up databases/connections
             # So previously created databases are not still cached in the instance_cache
             gc.collect()


### PR DESCRIPTION
I'm using this project to run SQL logic tests in https://github.com/mlafeldt/quack-zig and noticed that the output contains wrong test offsets. Here's the fix. 😀

Before:

```
❯ zig build test -Dduckdb-version=1.2.0
[0/2] test/sql/quack.test
SUCCESS
[1/2] test/sql/quack2.test
SUCCESS
```

After:

```
❯ zig build test -Dduckdb-version=1.2.0
[1/2] test/sql/quack.test
SUCCESS
[2/2] test/sql/quack2.test
SUCCESS
```