### PR TITLE
Allow subclassing of `SQLLogicContext`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Compiled python
 *.pyc
+build/
+*.egg-info

--- a/duckdb_sqllogictest/parser/parser.py
+++ b/duckdb_sqllogictest/parser/parser.py
@@ -442,7 +442,8 @@ class SQLLogicParser:
             self.fail(
                 f"unzip: input does not end in a valid file extension ({extension}), accepted options are: {accepted_options}"
             )
-        destination = params[1] if len(params) == 2 else f'__TEST_DIR__/{stem}'
+        # Handles `NULL` case here so downstream code doesn't have to bother about it
+        destination = params[1] if len(params) == 2 and params[1] != 'NULL' else f'__TEST_DIR__/{stem}'
         return Unzip(header, self.current_line + 1, source, destination)
 
     # Decorators


### PR DESCRIPTION
I am re-using this as a package to parse SQLLogic tests, but I need to apply a custom logic for execution, so I need to subclass `SQLLogicContext`.