### PR TITLE
A few fixes identified while getting the latest to work with the `inet` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ This is a library for running SQLLogicTest tests on the DuckDB database engine. 
 
 ## Usage
 
-The SQLLogicTest runner can be used through pytest, for example:
+The SQLLogicTest runner can be used through pytest, for example, when running from an installed version of DuckDB SQLLogicTest:
+
+```bash
+python3 -m sqllogic.test_sqllogic --duckdb-root-dir $HOME/duckdb --path test/sql/types/list/list_distinct.test
+```
+
+or if running locally:
+
 ```bash
 python3 -m pytest sqllogic/test_sqllogic.py --duckdb-root-dir $HOME/duckdb --path test/sql/types/list/list_distinct.test
 ```
+
+Note that the `--duckdb-root-dir` can be an external extension directory as well.

--- a/duckdb_sqllogictest/result.py
+++ b/duckdb_sqllogictest/result.py
@@ -1130,6 +1130,10 @@ class SQLLogicContext:
             if param == 'skip_reload':
                 self.runner.skip_reload = True
                 return RequireResult.PRESENT
+            if param == 'notwindows' and os.name != 'nt':
+                return RequireResult.PRESENT
+            if param == 'windows' and os.name == 'nt':
+                return RequireResult.PRESENT
             return RequireResult.MISSING
 
         # Already loaded

--- a/duckdb_sqllogictest/result.py
+++ b/duckdb_sqllogictest/result.py
@@ -1167,7 +1167,7 @@ class SQLLogicContext:
                 excluded_from_autoloading = False
                 break
 
-        if param in self.runner.extension_map:
+        if self.runner.get_extension_path(param):
             self.runner.database.load_extension(self, param)
             self.runner.extensions.add(param)
             return RequireResult.PRESENT

--- a/duckdb_sqllogictest/result.py
+++ b/duckdb_sqllogictest/result.py
@@ -1149,8 +1149,7 @@ class SQLLogicContext:
         ).fetchone()[0]
         if param == "no_extension_autoloading":
             if autoload_known_extensions:
-                # If autoloading is on, we skip this test
-                return RequireResult.MISSING
+                connection.execute("SET autoload_known_extensions=false")
             return RequireResult.PRESENT
 
         allow_unsigned_extensions = connection.execute(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         "duckdb",
-        "termcolor"
+        "termcolor",
+        "pytest"
     ],
     extras_require={
     },


### PR DESCRIPTION
I was getting starting with the `inet` extension, but the test tests were broken after the latest MR where the `__main__` was removed. 

* Update README with some pointers
    * It took me a few iterations to figure out the right way to call the sqllogictest script from an installed instance of the package, so I've included instructions to make it easier for the next person
* Properly support `notwindows` and `windows` requires. 
* Honor `require no_extension_autoloading`
* Fix requiring a local extension from the auto-generated path
* Add pytest to the dependencies, since it is required to follow the README instructions, and modules importing `pyttest` are installed with the package