### PR TITLE
Implement tags support

### DIFF
--- a/duckdb_sqllogictest/__init__.py
+++ b/duckdb_sqllogictest/__init__.py
@@ -20,6 +20,7 @@ from .statement import (
     Sleep,
     SleepUnit,
     Skip,
+    Tags,
     Unzip,
     Unskip,
 )
@@ -55,6 +56,7 @@ __all__ = [
     Unskip,
     SkipIf,
     OnlyIf,
+    Tags,
     SQLLogicParser,
     SQLParserException
 ]

--- a/duckdb_sqllogictest/parser/parser.py
+++ b/duckdb_sqllogictest/parser/parser.py
@@ -29,6 +29,7 @@ from duckdb_sqllogictest.statement import (
     Unzip,
     Unskip,
     SortStyle,
+    Tags,
 )
 from duckdb_sqllogictest.statement.sleep import get_sleep_unit, SleepUnit
 
@@ -91,6 +92,7 @@ class SQLLogicParser:
             TokenType.SQLLOGIC_RECONNECT: self.statement_reconnect,
             TokenType.SQLLOGIC_SLEEP: self.statement_sleep,
             TokenType.SQLLOGIC_UNZIP: self.statement_unzip,
+            TokenType.SQLLOGIC_TAGS: self.statement_tags,
             TokenType.SQLLOGIC_INVALID: None,
         }
         self.DECORATORS = {
@@ -422,6 +424,10 @@ class SQLLogicParser:
             self.fail(f"Unrecognized sleep mode - expected {create_formatted_list(options)}")
         return Sleep(header, self.current_line + 1, sleep_duration, sleep_unit)
 
+
+    def statement_tags(self, header: Token) -> Optional[BaseStatement]:
+        return Tags(header, self.current_line + 1)
+
     def statement_unzip(self, header: Token) -> Optional[BaseStatement]:
         params = header.parameters
         if len(params) != 1 and len(params) != 2:
@@ -574,6 +580,7 @@ class SQLLogicParser:
             TokenType.SQLLOGIC_RESTART,
             TokenType.SQLLOGIC_RECONNECT,
             TokenType.SQLLOGIC_SLEEP,
+            TokenType.SQLLOGIC_TAGS,
             TokenType.SQLLOGIC_UNZIP,
         ]
 
@@ -612,11 +619,13 @@ class SQLLogicParser:
             "reconnect": TokenType.SQLLOGIC_RECONNECT,
             "unzip": TokenType.SQLLOGIC_UNZIP,
             "sleep": TokenType.SQLLOGIC_SLEEP,
+            "tags": TokenType.SQLLOGIC_TAGS,
         }
 
         if token in token_map:
             return token_map[token]
         else:
+            print("heeeeerrre")
             self.fail(f"Unrecognized parameter {token}")
             return TokenType.SQLLOGIC_INVALID
 

--- a/duckdb_sqllogictest/result.py
+++ b/duckdb_sqllogictest/result.py
@@ -25,6 +25,7 @@ from duckdb_sqllogictest.statement import (
     Unzip,
     SortStyle,
     Unskip,
+    Tags,
 )
 
 from duckdb_sqllogictest.expected_result import ExpectedResult
@@ -803,6 +804,7 @@ class SQLLogicContext:
             Unzip: self.execute_unzip,
             Loop: self.execute_loop,
             Foreach: self.execute_foreach,
+            Tags: self.execute_tags,
             Endloop: None,  # <-- should never be encountered outside of Loop/Foreach
         }
 
@@ -1284,6 +1286,10 @@ class SQLLogicContext:
                     # Propagate the exception
                     self.error = context.error
                     raise self.error
+
+    def execute_tags(self, _tags: Tags):
+        # Tags are ignored in this implementation
+        pass
 
     def execute_foreach(self, foreach: Foreach):
         statements = self.get_loop_statements()

--- a/duckdb_sqllogictest/statement/__init__.py
+++ b/duckdb_sqllogictest/statement/__init__.py
@@ -15,6 +15,7 @@ from .restart import Restart
 from .reconnect import Reconnect
 from .sleep import Sleep, SleepUnit
 from .unzip import Unzip
+from .tags import Tags
 
 from .skip import Skip, Unskip
 
@@ -39,4 +40,5 @@ __all__ = [
     Unzip,
     Unskip,
     SortStyle,
+    Tags,
 ]

--- a/duckdb_sqllogictest/statement/tags.py
+++ b/duckdb_sqllogictest/statement/tags.py
@@ -1,0 +1,7 @@
+from duckdb_sqllogictest.base_statement import BaseStatement
+from duckdb_sqllogictest.token import Token
+
+class Tags(BaseStatement):
+    def __init__(self, header: Token, line: int):
+        super().__init__(header, line)
+        self.tags = header.parameters

--- a/duckdb_sqllogictest/token.py
+++ b/duckdb_sqllogictest/token.py
@@ -23,6 +23,7 @@ class TokenType(Enum):
     SQLLOGIC_RECONNECT = auto()
     SQLLOGIC_SLEEP = auto()
     SQLLOGIC_UNZIP = auto()
+    SQLLOGIC_TAGS = auto()
 
 
 class Token:


### PR DESCRIPTION
A new `tags` keyword was [recently introduced](https://github.com/duckdb/duckdb/blob/9612b5bea5a6df924daf5ce696d6992df2483bfe/test/sql/pragma/test_pragma_version.test#L5) in the SQLLogic tests.

This lead to parsing failing with:
```
  File "/opt/homebrew/lib/python3.11/site-packages/duckdb_sqllogictest/parser/parser.py", line 462, in parse
    token = self.tokenize()
            ^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/duckdb_sqllogictest/parser/parser.py", line 556, in tokenize
    result.type = self.command_to_token(argument_list[0])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/duckdb_sqllogictest/parser/parser.py", line 620, in command_to_token
    self.fail(f"Unrecognized parameter {token}")
  File "/opt/homebrew/lib/python3.11/site-packages/duckdb_sqllogictest/parser/parser.py", line 190, in fail
    raise SQLParserException(error_message)
duckdb_sqllogictest.parser.parser.SQLParserException: Parser Error: /Users/y/workspace/motherduck/private-duckdb/duckdb_unittest_tempdir/bwc/specs/v1.4.3/test/sql/pragma/test_pragma_version.test:5: Unrecognized parameter tags
```

This PR adds trivial support for it (only consumes it silently)
