### PR TITLE
`matches_regex` breaks on patterns with leading inline flags

### DIFF
--- a/duckdb_sqllogictest/result.py
+++ b/duckdb_sqllogictest/result.py
@@ -470,10 +470,18 @@ def matches_regex(input: str, actual_str: str) -> bool:
         should_match = False
         regex_str = input.replace("<!REGEX>:", "")
     # The exact match will never be the same, allow leading and trailing messages
+    # Extract leading inline flags (e.g. (?s), (?i)) so they stay at position 0
+    # after prepending '.*', as Python 3.11+ requires global flags at the start.
+    leading_flags = ""
+    flag_match = re.match(r'^(\(\?[aiLmsux]+\))', regex_str)
+    if flag_match:
+        leading_flags = flag_match.group(1)
+        regex_str = regex_str[len(leading_flags):]
     if regex_str[:2] != '.*':
         regex_str = ".*" + regex_str
     if regex_str[-2:] != '.*':
         regex_str = regex_str + '.*'
+    regex_str = leading_flags + regex_str
 
     re_options = re.DOTALL
     re_pattern = re.compile(regex_str, re_options)


### PR DESCRIPTION
`matches_regex` in the prepends `.*` to regex patterns, pushing inline global flags like `(?s)` to a non-zero position. Python 3.11 (don't know about other versions) requires global flags at position 0. As a result, the test runner fails for _error_location_not_duplicated.test_ which uses `<!REGEX>:(?s).*LINE 1:.*LINE 1:.*.`